### PR TITLE
Added version variables and put in proper order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,15 +96,21 @@ def versions = [
     commonsLang3: '3.7',
     commonsIo: '2.5',
     jacksonCore: '2.9.5',
+    jsonAssert: '1.2.3',
+    junit: '4.12',
     lombok: '1.16.16',
     logstashLogBackEncoder: '4.8',
+    nimbus: '5.1',
+    pdfbox: '2.0.8',
     powerMock: '1.7.3',
     puppyCrawl: '7.6',
     reformsJavaLogging: '2.0.2',
+    restAssured: '3.0.3',
     serenity: '1.5.2',
     serenityCucumber: '1.1.3',
     serviceTokenGenerator: '0.6.0',
     springfoxSwagger: '2.7.0',
+    unirest: '1.4.9',
     wiremockVersion: '2.8.0'
 ]
 
@@ -125,10 +131,10 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.reformsJavaLogging
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformsJavaLogging
     compile (group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator){
-        exclude group: 'io.reactivex', module: 'rxnetty'
-        exclude group: 'io.reactivex', module: 'rxnetty-servo'
         exclude group: 'io.reactivex', module: 'io.reactivex'
+        exclude group: 'io.reactivex', module: 'rxnetty'
         exclude group: 'io.reactivex', module: 'rxnetty-contexts'
+        exclude group: 'io.reactivex', module: 'rxnetty-servo'
     }
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testCompile group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremockVersion
@@ -140,20 +146,19 @@ dependencies {
     runtime('org.springframework.boot:spring-boot-devtools')
 
     //integration test
-    integrationTestCompile group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
-    integrationTestCompile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '5.1'
-    integrationTestCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.3'
-    integrationTestCompile group: 'junit', name: 'junit', version: '4.12'
-    integrationTestCompile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '5.1'
+    integrationTestCompile group: 'com.mashape.unirest', name: 'unirest-java', version: versions.unirest
+    integrationTestCompile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: versions.nimbus
+    integrationTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+    integrationTestCompile group: 'junit', name: 'junit', version: versions.junit
     integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
     integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-cucumber', version: versions.serenityCucumber
     integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
     integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
     integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
-    integrationTestCompile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.8'
     integrationTestCompile group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonsLang3
+    integrationTestCompile group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
     integrationTestCompile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    integrationTestCompile group: 'org.skyscreamer', name:'jsonassert', version: '1.2.3'
+    integrationTestCompile group: 'org.skyscreamer', name:'jsonassert', version: versions.jsonAssert
     integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     integrationTestCompile group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator
@@ -211,13 +216,12 @@ def sonarExclusions = [
 sonarqube {
     properties {
         property "sonar.exclusions", sonarExclusions.join(", ")
-        property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
         property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/apiTest.exec"
+        property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
         property "sonar.projectKey", "DivorceDocumentGenerator"
         property "sonar.projectName", "Divorce :: document-generator"
     }
 }
-
 
 task developAddRelaseSuffix() {
     version = "${version}-SNAPSHOT"


### PR DESCRIPTION
Tiny changes to build.gradle file to put version numbers as defined variables and put rest of dependencies in alphabetical order.