### PR TITLE
Disable unnecessary second service auth healthcheck

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -35,10 +35,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type , product, component) {
     loadVaultSecrets(secrets)
 
-    before('functionalTest:aat') {
-        env.TEST_ENVIRONMENT = "aat"
-    }
-
     after('checkout') {
         echo '${product}-${component} checked out'
     }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -9,7 +9,7 @@ locals {
 
 module "div-dgs" {
   source       = "git@github.com:hmcts/moj-module-webapp.git?ref=master"
-  product      = "${var.reform_team}-${var.reform_service_name}"
+  product      = "${var.product}-${var.component}"
   location     = "${var.location}"
   env          = "${var.env}"
   ilbIp        = "${var.ilbIp}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -2,9 +2,9 @@ locals {
   ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
   local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
 
-  evidence_management_client_api_url = "http://${var.evidence_management_client_api_url_part}-${local.local_env}.service.${local.ase_name}.internal"
-  pdf_service_url                    = "http://${var.pdf_service_url_part}-${local.local_env}.service.${local.ase_name}.internal"
-  idam_s2s_url                       = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.${local.ase_name}.internal"
+  evidence_management_client_api_url = "http://${var.evidence_management_client_api_url_part}-${local.local_env}.service.core-compute-${local.local_env}.internal"
+  pdf_service_url                    = "http://${var.pdf_service_url_part}-${local.local_env}.service.core-compute-${local.local_env}.internal"
+  idam_s2s_url                       = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }
 
 module "div-dgs" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,9 +1,10 @@
 locals {
   ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
 
-  evidence_management_client_api_url = "http://${var.evidence_management_client_api_url_part}-${var.env}.service.${local.ase_name}.internal"
-  pdf_service_url                    = "http://${var.pdf_service_url_part}-${var.env}.service.${local.ase_name}.internal"
-  idam_s2s_url                       = "http://${var.idam_s2s_url_prefix}-${var.env}.service.${local.ase_name}.internal"
+  evidence_management_client_api_url = "http://${var.evidence_management_client_api_url_part}-${local.local_env}.service.${local.ase_name}.internal"
+  pdf_service_url                    = "http://${var.pdf_service_url_part}-${local.local_env}.service.${local.ase_name}.internal"
+  idam_s2s_url                       = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.${local.ase_name}.internal"
 }
 
 module "div-dgs" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -7,7 +7,7 @@ output "vaultUri" {
 }
 
 output "idam_s2s_url" {
-    value = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.${local.ase_name}.internal"
+    value = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }
 
 output "test_environment" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -7,5 +7,9 @@ output "vaultUri" {
 }
 
 output "idam_s2s_url" {
-    value = "http://${var.idam_s2s_url_prefix}-${var.env}.service.${local.ase_name}.internal"
+    value = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.${local.ase_name}.internal"
+}
+
+output "test_environment" {
+    value = "${local.local_env}"
 }

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -4,7 +4,7 @@
 logging.level.uk.gov.hmcts.ccd=DEBUG
 logging.level.org.springframework.web=DEBUG
 
-env=${TEST_ENVIRONMENT:local}
+env=${test_environment:local}
 
 ###############################################
 #  IDAM Auth S2S                              #

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/DocumentGeneratorApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/DocumentGeneratorApplication.java
@@ -2,8 +2,9 @@ package uk.gov.hmcts.reform.divorce.documentgenerator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuthHealthIndicator;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ServiceAuthHealthIndicator.class})
 public class DocumentGeneratorApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
# Description

Disabling the second service auth health check happening inside the service auth library. This will also disable 2 second timeout of feign client health check.

This PR also contains fixes for getting the build working on Preview environment

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
