### PR TITLE
Added passing in filename to storeDocument in Evidence Management

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/management/test/stub/impl/EvidenceManagementServiceStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/management/test/stub/impl/EvidenceManagementServiceStub.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.divorce.documentgenerator.service.EvidenceManagementS
 
 import java.time.Clock;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
@@ -25,9 +24,7 @@ public class EvidenceManagementServiceStub implements EvidenceManagementService,
     private final Clock clock = Clock.systemDefaultZone();
 
     @Override
-    public FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken) {
-        String fileName = UUID.randomUUID().toString();
-
+    public FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken, String fileName) {
         DATA_STORE.put(fileName, document);
 
         FileUploadResponse fileUploadResponse = new FileUploadResponse(HttpStatus.OK);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/DocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/DocumentManagementService.java
@@ -8,7 +8,7 @@ public interface DocumentManagementService {
     GeneratedDocumentInfo generateAndStoreDocument(String templateName, Map<String, Object> placeholders,
                                                    String authorizationToken);
 
-    GeneratedDocumentInfo storeDocument(byte[] document, String authorizationToken);
+    GeneratedDocumentInfo storeDocument(byte[] document, String authorizationToken, String fileName);
 
     byte[] generateDocument(String templateName, Map<String, Object> placeholders);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/EvidenceManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/EvidenceManagementService.java
@@ -3,5 +3,5 @@ package uk.gov.hmcts.reform.divorce.documentgenerator.service;
 import uk.gov.hmcts.reform.divorce.documentgenerator.domain.response.FileUploadResponse;
 
 public interface EvidenceManagementService {
-    FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken);
+    FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken, String fileName);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
@@ -80,6 +80,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
             case "divorceminipetition" : fileName = MINI_PETITION_NAME_FOR_PDF_FILE;
                 break;
             default : fileName = DEFAULT_NAME_FOR_PDF_FILE;
+                break;
         }
 
         return fileName;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
@@ -24,7 +24,7 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ss.SSS";
     private static final String DEFAULT_NAME_FOR_PDF_FILE = "DivorceDocument.pdf";
     private static final String MINI_PETITION_NAME_FOR_PDF_FILE = "DivorcePetition.pdf";
-    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "DivorceResponse.pdf";
+    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "AOSInvitation.pdf";
 
     private final Clock clock = Clock.systemDefaultZone();
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
@@ -70,11 +70,14 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     }
 
     private String getFileNameFromTemplateName(String templateName) {
-        String fileName = DEFAULT_NAME_FOR_PDF_FILE;
+        String fileName = null;
 
-        switch(templateName) {
-            case "aosinvitation" : fileName = "DivorceResponse.pdf"; break;
+        switch (templateName) {
+            case "aosinvitation" : fileName = "DivorceResponse.pdf";
+                break;
             case "divorceminipetition" : fileName = "DivorcePetition.pdf";
+                break;
+            default : fileName = DEFAULT_NAME_FOR_PDF_FILE;
         }
 
         return fileName;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImpl.java
@@ -23,6 +23,8 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
     private static final String CURRENT_DATE_KEY = "current_date";
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ss.SSS";
     private static final String DEFAULT_NAME_FOR_PDF_FILE = "DivorceDocument.pdf";
+    private static final String MINI_PETITION_NAME_FOR_PDF_FILE = "DivorcePetition.pdf";
+    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "DivorceResponse.pdf";
 
     private final Clock clock = Clock.systemDefaultZone();
 
@@ -73,9 +75,9 @@ public class DocumentManagementServiceImpl implements DocumentManagementService 
         String fileName = null;
 
         switch (templateName) {
-            case "aosinvitation" : fileName = "DivorceResponse.pdf";
+            case "aosinvitation" : fileName = AOS_INVITATION_NAME_FOR_PDF_FILE;
                 break;
-            case "divorceminipetition" : fileName = "DivorcePetition.pdf";
+            case "divorceminipetition" : fileName = MINI_PETITION_NAME_FOR_PDF_FILE;
                 break;
             default : fileName = DEFAULT_NAME_FOR_PDF_FILE;
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/EvidenceManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/EvidenceManagementServiceImpl.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.divorce.documentgenerator.service.EvidenceManagementS
 import uk.gov.hmcts.reform.divorce.documentgenerator.util.NullOrEmptyValidator;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -29,7 +30,7 @@ import java.util.List;
 public class EvidenceManagementServiceImpl implements EvidenceManagementService {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String FILE_PARAMETER = "file";
-    private static final String DEFAULT_NAME_FOR_PDF_FILE = "D8MiniPetition.pdf";
+    private static final String DEFAULT_NAME_FOR_PDF_FILE = "DivorceDocument.pdf";
 
     @Value("${service.evidence-management-client-api.uri}")
     private String evidenceManagementEndpoint;
@@ -38,11 +39,11 @@ public class EvidenceManagementServiceImpl implements EvidenceManagementService 
     private RestTemplate restTemplate;
 
     @Override
-    public FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken) {
+    public FileUploadResponse storeDocumentAndGetInfo(byte[] document, String authorizationToken, String fileName) {
         log.info("Save document call to evidence management is made document of size [{}]", document.length);
 
         try {
-            FileUploadResponse fileUploadResponse = storeDocument(document, authorizationToken);
+            FileUploadResponse fileUploadResponse = storeDocument(document, authorizationToken, fileName);
 
             if (fileUploadResponse.getStatus() == HttpStatus.OK) {
                 return fileUploadResponse;
@@ -54,13 +55,13 @@ public class EvidenceManagementServiceImpl implements EvidenceManagementService 
         }
     }
 
-    private FileUploadResponse storeDocument(byte[] document, String authorizationToken) {
+    private FileUploadResponse storeDocument(byte[] document, String authorizationToken, String fileName) {
         NullOrEmptyValidator.requireNonEmpty(document);
 
         ResponseEntity<List<FileUploadResponse>> responseEntity = restTemplate.exchange(evidenceManagementEndpoint,
                 HttpMethod.POST,
                 new HttpEntity<>(
-                        buildRequest(document, DEFAULT_NAME_FOR_PDF_FILE),
+                        buildRequest(document, Optional.ofNullable(fileName).orElse(DEFAULT_NAME_FOR_PDF_FILE)),
                     getHttpHeaders(authorizationToken)),
                 new ParameterizedTypeReference<List<FileUploadResponse>>() {
                 });

--- a/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/management/test/stub/impl/EvidenceManagementServiceStubUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/management/test/stub/impl/EvidenceManagementServiceStubUTest.java
@@ -12,11 +12,9 @@ import uk.gov.hmcts.reform.divorce.documentgenerator.domain.response.FileUploadR
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -46,33 +44,24 @@ public class EvidenceManagementServiceStubUTest {
 
     @Test
     public void givenADocument_whenStoreDocumentAndGetInfo_thenReturnInfo() {
+        final String testFileName = "testFileName";
         final Instant instant = Instant.now();
         mockAndSetClock(instant);
 
         dataStore.clear();
 
-        FileUploadResponse actual = classUnderTest.storeDocumentAndGetInfo(NEW_FILE, "testToken");
+        FileUploadResponse actual = classUnderTest.storeDocumentAndGetInfo(NEW_FILE, "testToken", testFileName);
 
         Map.Entry<String, byte[]> entry = dataStore.entrySet().iterator().next();
 
         String fileName = entry.getKey();
 
-        verifyUuid(fileName);
-
+        assertEquals(testFileName, fileName);
         assertEquals(NEW_FILE, entry.getValue());
         assertEquals(EXPECTED_FILE_URL_PREFIX + fileName, actual.getFileUrl());
         assertEquals(MediaType.APPLICATION_PDF_VALUE, actual.getMimeType());
         assertEquals(instant.toString(), actual.getCreatedOn());
         assertEquals(CREATED_BY, actual.getCreatedBy());
-    }
-
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    private void verifyUuid(String uuidString) {
-        try {
-            UUID.fromString(uuidString);
-        } catch (IllegalArgumentException exception) {
-            fail("Not a valid UUID String");
-        }
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
@@ -79,7 +79,8 @@ public class DocumentManagementServiceImplUTest {
         doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
                 "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
         doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
-                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
+                "storeDocument", byte[].class, String.class, String.class))
+                        .withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
 
@@ -111,7 +112,8 @@ public class DocumentManagementServiceImplUTest {
         doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
                 "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
         doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
-                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, AOS_INVITATION_NAME_FOR_PDF_FILE);
+                "storeDocument", byte[].class, String.class, String.class))
+                        .withArguments(data, authToken, AOS_INVITATION_NAME_FOR_PDF_FILE);
 
         GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
 
@@ -143,7 +145,8 @@ public class DocumentManagementServiceImplUTest {
         doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
                 "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
         doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
-                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, MINI_PETITION_NAME_FOR_PDF_FILE);
+                "storeDocument", byte[].class, String.class, String.class))
+                        .withArguments(data, authToken, MINI_PETITION_NAME_FOR_PDF_FILE);
 
         GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
 
@@ -162,14 +165,16 @@ public class DocumentManagementServiceImplUTest {
 
         final GeneratedDocumentInfo expected = new GeneratedDocumentInfo();
 
-        when(evidenceManagementService.storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE)).thenReturn(fileUploadResponse);
+        when(evidenceManagementService.storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE))
+                .thenReturn(fileUploadResponse);
         when(GeneratedDocumentInfoMapper.mapToGeneratedDocumentInfo(fileUploadResponse)).thenReturn(expected);
 
         GeneratedDocumentInfo actual = classUnderTest.storeDocument(data, "test", DEFAULT_NAME_FOR_PDF_FILE);
 
         assertEquals(expected, actual);
 
-        Mockito.verify(evidenceManagementService, Mockito.times(1)).storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE);
+        Mockito.verify(evidenceManagementService, Mockito.times(1))
+                .storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE);
         verifyStatic(GeneratedDocumentInfoMapper.class);
         GeneratedDocumentInfoMapper.mapToGeneratedDocumentInfo(fileUploadResponse);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
@@ -40,7 +40,7 @@ public class DocumentManagementServiceImplUTest {
 
     private static final String DEFAULT_NAME_FOR_PDF_FILE = "DivorceDocument.pdf";
     private static final String MINI_PETITION_NAME_FOR_PDF_FILE = "DivorcePetition.pdf";
-    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "DivorceResponse.pdf";
+    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "AOSInvitation.pdf";
 
     @Mock
     private TemplateManagementService templateManagementService;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/DocumentManagementServiceImplUTest.java
@@ -37,6 +37,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({GeneratedDocumentInfoMapper.class, HtmlFieldFormatter.class, DocumentManagementServiceImpl.class})
 public class DocumentManagementServiceImplUTest {
+
+    private static final String DEFAULT_NAME_FOR_PDF_FILE = "DivorceDocument.pdf";
+    private static final String MINI_PETITION_NAME_FOR_PDF_FILE = "DivorcePetition.pdf";
+    private static final String AOS_INVITATION_NAME_FOR_PDF_FILE = "DivorceResponse.pdf";
+
     @Mock
     private TemplateManagementService templateManagementService;
 
@@ -74,7 +79,7 @@ public class DocumentManagementServiceImplUTest {
         doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
                 "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
         doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
-                "storeDocument", byte[].class, String.class)).withArguments(data, authToken);
+                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
 
@@ -83,7 +88,71 @@ public class DocumentManagementServiceImplUTest {
         verifyPrivate(classUnderTest, Mockito.times(1))
                 .invoke("generateDocument", templateName, placeholderMap);
         verifyPrivate(classUnderTest, Mockito.times(1))
-                .invoke("storeDocument", data, authToken);
+                .invoke("storeDocument", data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
+    }
+
+    @Test
+    public void whenGenerateAndStoreDocument_givenTemplateNameIsAosInvitation_thenProceedAsExpected() throws Exception {
+        final DocumentManagementServiceImpl classUnderTest = spy(new DocumentManagementServiceImpl());
+
+        final byte[] data = {1};
+        final String templateName = "aosinvitation";
+        final Map<String, Object> placeholderMap = new HashMap<>();
+        final GeneratedDocumentInfo expected = new GeneratedDocumentInfo();
+        final Instant instant = Instant.now();
+        final String authToken = "someToken";
+
+        expected.setCreatedOn("someCreatedDate");
+        expected.setMimeType("someMimeType");
+        expected.setUrl("someUrl");
+
+        mockAndSetClock(instant);
+
+        doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
+                "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
+        doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
+                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, AOS_INVITATION_NAME_FOR_PDF_FILE);
+
+        GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
+
+        assertEquals(expected, actual);
+
+        verifyPrivate(classUnderTest, Mockito.times(1))
+                .invoke("generateDocument", templateName, placeholderMap);
+        verifyPrivate(classUnderTest, Mockito.times(1))
+                .invoke("storeDocument", data, authToken, AOS_INVITATION_NAME_FOR_PDF_FILE);
+    }
+
+    @Test
+    public void whenGenerateAndStoreDocument_givenTemplateNameIsMiniPetition_thenProceedAsExpected() throws Exception {
+        final DocumentManagementServiceImpl classUnderTest = spy(new DocumentManagementServiceImpl());
+
+        final byte[] data = {1};
+        final String templateName = "divorceminipetition";
+        final Map<String, Object> placeholderMap = new HashMap<>();
+        final GeneratedDocumentInfo expected = new GeneratedDocumentInfo();
+        final Instant instant = Instant.now();
+        final String authToken = "someToken";
+
+        expected.setCreatedOn("someCreatedDate");
+        expected.setMimeType("someMimeType");
+        expected.setUrl("someUrl");
+
+        mockAndSetClock(instant);
+
+        doReturn(data).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
+                "generateDocument", String.class, Map.class)).withArguments(templateName, placeholderMap);
+        doReturn(expected).when(classUnderTest, MemberMatcher.method(DocumentManagementServiceImpl.class,
+                "storeDocument", byte[].class, String.class, String.class)).withArguments(data, authToken, MINI_PETITION_NAME_FOR_PDF_FILE);
+
+        GeneratedDocumentInfo actual = classUnderTest.generateAndStoreDocument(templateName, placeholderMap, authToken);
+
+        assertEquals(expected, actual);
+
+        verifyPrivate(classUnderTest, Mockito.times(1))
+                .invoke("generateDocument", templateName, placeholderMap);
+        verifyPrivate(classUnderTest, Mockito.times(1))
+                .invoke("storeDocument", data, authToken, MINI_PETITION_NAME_FOR_PDF_FILE);
     }
 
     @Test
@@ -93,14 +162,14 @@ public class DocumentManagementServiceImplUTest {
 
         final GeneratedDocumentInfo expected = new GeneratedDocumentInfo();
 
-        when(evidenceManagementService.storeDocumentAndGetInfo(data, "test")).thenReturn(fileUploadResponse);
+        when(evidenceManagementService.storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE)).thenReturn(fileUploadResponse);
         when(GeneratedDocumentInfoMapper.mapToGeneratedDocumentInfo(fileUploadResponse)).thenReturn(expected);
 
-        GeneratedDocumentInfo actual = classUnderTest.storeDocument(data, "test");
+        GeneratedDocumentInfo actual = classUnderTest.storeDocument(data, "test", DEFAULT_NAME_FOR_PDF_FILE);
 
         assertEquals(expected, actual);
 
-        Mockito.verify(evidenceManagementService, Mockito.times(1)).storeDocumentAndGetInfo(data, "test");
+        Mockito.verify(evidenceManagementService, Mockito.times(1)).storeDocumentAndGetInfo(data, "test", DEFAULT_NAME_FOR_PDF_FILE);
         verifyStatic(GeneratedDocumentInfoMapper.class);
         GeneratedDocumentInfoMapper.mapToGeneratedDocumentInfo(fileUploadResponse);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/EvidenceManagementServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/documentgenerator/service/impl/EvidenceManagementServiceImplUTest.java
@@ -67,7 +67,8 @@ public class EvidenceManagementServiceImplUTest {
         final RuntimeException documentStorageException = new RuntimeException();
 
         doThrow(documentStorageException).when(classUnderTest,
-                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument", byte[].class, String.class, String.class))
+                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument",
+                    byte[].class, String.class, String.class))
                 .withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         try {
@@ -77,7 +78,8 @@ public class EvidenceManagementServiceImplUTest {
             assertEquals(documentStorageException, exception.getCause());
         }
 
-        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument", data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
+        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument",
+            data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
     }
 
     @Test(expected = DocumentStorageException.class)
@@ -88,12 +90,14 @@ public class EvidenceManagementServiceImplUTest {
         final FileUploadResponse fileUploadResponse = new FileUploadResponse(HttpStatus.SERVICE_UNAVAILABLE);
 
         doReturn(fileUploadResponse).when(classUnderTest,
-                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument", byte[].class, String.class, String.class))
+                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument",
+                    byte[].class, String.class, String.class))
                 .withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         classUnderTest.storeDocumentAndGetInfo(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
-        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument", data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
+        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument",
+            data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
     }
 
     @Test
@@ -104,14 +108,16 @@ public class EvidenceManagementServiceImplUTest {
         final FileUploadResponse expected = new FileUploadResponse(HttpStatus.OK);
 
         doReturn(expected).when(classUnderTest,
-                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument", byte[].class, String.class, String.class))
+                MemberMatcher.method(EvidenceManagementServiceImpl.class, "storeDocument",
+                    byte[].class, String.class, String.class))
                 .withArguments(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         FileUploadResponse actual = classUnderTest.storeDocumentAndGetInfo(data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
 
         assertEquals(expected, actual);
 
-        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument", data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
+        verifyPrivate(classUnderTest, Mockito.times(1)).invoke("storeDocument",
+            data, authToken, DEFAULT_NAME_FOR_PDF_FILE);
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3711

This PR changes the filename to be stored in DM Store from the default option to one based on the passed in template.
If the template doesn't exist then the default option is used (modified to be more generic).