### PR TITLE
Fix vulnerability check

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -73,4 +73,8 @@
         <gav regex="true">^com\.google\.guava:guava:.*$</gav>
         <cpe>cpe:/a:google:guava</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[ slf4j only has a beta version released with the 'fix', looks like lots of changes in it... ]]></notes>
+        <cve>CVE-2018-8088</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
# Description

Supress slf4j vulnerability check. We can't upgrade to the new
version of this dependency since it is only in beta and causes
breaking changes in our apps.
