### PR TITLE
Supress dependency check

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -28,6 +28,7 @@
         <cve>CVE-2011-2732</cve>
         <cve>CVE-2012-5055</cve>
         <cve>CVE-2018-1260</cve>
+        <cve>CVE-2018-1258</cve>
     </suppress>
 
     <suppress>


### PR DESCRIPTION
Supressing dependency check

spring-security-rsa-1.0.8.RELEASE.jar: ids:(cpe:/a:pivotal_software:spring_security:1.0.8, org.springframework.security:spring-security-rsa:1.0.8.RELEASE) : CVE-2018-1258

