### PR TITLE
Force Jackson DataBind to 2.9.9 from 2.9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ def versions = [
     feignHttpClient: '10.2.0',
     gradlePitest: '1.3.0',
     guava: '27.0.1-jre',
-    jacksonDatabind: '2.9.8',
+    jacksonDatabind: '2.9.9',
     jsonAssert: '1.2.3',
     junit: '4.12',
     lombok: '1.16.16',


### PR DESCRIPTION
Resolves dependency check issue CVE-2019-12086