### PR TITLE
Override Spring's management endpoint cache to 30 seconds in AAT/Preview

### DIFF
--- a/charts/div-dgs/values.aat.template.yaml
+++ b/charts/div-dgs/values.aat.template.yaml
@@ -8,6 +8,7 @@ java:
         PDF_SERVICE_BASEURL : "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
         REFORM_ENVIRONMENT : "aat"
         DOCMOSIS_SERVICE_RENDER_URL: "https://docmosis-development.platform.hmcts.net/rs/render"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-dgs/values.preview.template.yaml
+++ b/charts/div-dgs/values.preview.template.yaml
@@ -8,6 +8,7 @@ java:
         PDF_SERVICE_BASEURL : "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
         REFORM_ENVIRONMENT : "aat"
         DOCMOSIS_SERVICE_RENDER_URL: "https://docmosis-development.platform.hmcts.net/rs/render"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -2,3 +2,4 @@ vault_env = "preprod"
 capacity = "2"
 
 docmosis_service_url = "https://docmosis-development.platform.hmcts.net"
+health_check_ttl = 30000

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -44,7 +44,7 @@ module "div-dgs" {
     AUTH_IDAM_CLIENT_SECRET                               = "${data.azurerm_key_vault_secret.idam-secret.value}"
     DOCMOSIS_SERVICE_RENDER_URL                           = "${var.docmosis_service_url}${var.docmosis_render_endpoint}"
     DOCMOSIS_SERVICE_ACCESS_KEY                           = "${data.azurerm_key_vault_secret.docmosis-api-key.value}"
-    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
+    MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE           = "${var.health_check_ttl}"
   }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -11,7 +11,7 @@ locals {
   nonPreviewVaultName = "${var.reform_team}-${var.env}"
   vaultName = "${var.env == "preview" ? local.previewVaultName : local.nonPreviewVaultName}"
   vaultUri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
-    
+
   asp_name = "${var.env == "prod" ? "div-dgs-prod" : "${var.raw_product}-${var.env}"}"
   asp_rg = "${var.env == "prod" ? "div-dgs-prod" : "${var.raw_product}-${var.env}"}"
 }
@@ -44,6 +44,7 @@ module "div-dgs" {
     AUTH_IDAM_CLIENT_SECRET                               = "${data.azurerm_key_vault_secret.idam-secret.value}"
     DOCMOSIS_SERVICE_RENDER_URL                           = "${var.docmosis_service_url}${var.docmosis_render_endpoint}"
     DOCMOSIS_SERVICE_ACCESS_KEY                           = "${data.azurerm_key_vault_secret.docmosis-api-key.value}"
+    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
   }
 }
 

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,3 +1,4 @@
 vault_env = "preprod"
 
 docmosis_service_url = "https://docmosis-development.platform.hmcts.net"
+health_check_ttl = 30000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -88,3 +88,8 @@ variable "docmosis_service_url" {
 variable "docmosis_render_endpoint" {
     default = "/rs/render"
 }
+
+variable "health_check_ttl" {
+    type = "string"
+    value = "4000"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -91,5 +91,5 @@ variable "docmosis_render_endpoint" {
 
 variable "health_check_ttl" {
     type = "string"
-    value = "4000"
+    value = "5000"
 }


### PR DESCRIPTION
# Description

To prevent hammering AAT, as every `/health` call checks _every_ dependent service, generating sometimes ~30 subsequent calls (e.g COS)

Tested locally via
`MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE=60000 ./gradlew clean bootrun`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
