### PR TITLE
Added missing flag to integrationTest properties

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/EMStoreIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/EMStoreIntegrationTest.java
@@ -22,9 +22,6 @@ public class EMStoreIntegrationTest extends IntegrationTest {
     private static final String X_PATH_TO_URL = "_links.self.href";
     private static final String COSTS_ORDER_INPUT_JSON = "costs-order.json";
 
-    @Value("${divorce.document.generator.uri}")
-    private String divDocumentGeneratorURI;
-
     @Test
     public void givenAllTheRightParameters_whenGeneratePDF_thenGeneratedPDFShouldBeStoredInEMStore() throws Exception {
         String requestBody = loadJson(VALID_INPUT_JSON);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/IntegrationTest.java
@@ -35,6 +35,9 @@ public abstract class IntegrationTest {
     @Value("${http.proxy:#{null}}")
     protected String httpProxy;
 
+    @Value("${feature-toggle.resp-solicitor-details}")
+    private static boolean featureToggleRespSolicitor;
+
     @Autowired
     private AuthTokenGenerator authTokenGenerator;
 
@@ -106,5 +109,9 @@ public abstract class IntegrationTest {
         }
 
         return userToken;
+    }
+
+    protected static boolean getFeatureToggleRespSolicitor() {
+        return featureToggleRespSolicitor;
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
@@ -32,7 +32,7 @@ public class PDFGenerationTest extends IntegrationTest {
     private final String inputJson;
     private final String expectedOutput;
 
-    @Value("${feature-toggle.toggle.feature_resp_solicitor_details}")
+    @Value("${feature-toggle.resp-solicitor-details}")
     private static boolean featureToggleRespSolicitor;
 
     public PDFGenerationTest(String fileName) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
@@ -83,6 +83,10 @@ public class PDFGenerationTest extends IntegrationTest {
 
         List testData = new ArrayList(basicTestData);
 
+        System.out.println("Feature toggle value is");
+        System.out.println(getFeatureToggleRespSolicitor());
+        System.out.println(System.getenv("FEATURE_RESP_SOLICITOR_DETAILS"));
+
         if (getFeatureToggleRespSolicitor()) {
             testData.addAll(Arrays.asList(new Object[][] {
                 {"AOS_Solicitor"},

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
@@ -32,9 +32,6 @@ public class PDFGenerationTest extends IntegrationTest {
     private final String inputJson;
     private final String expectedOutput;
 
-    @Value("${feature-toggle.resp-solicitor-details}")
-    private static boolean featureToggleRespSolicitor;
-
     public PDFGenerationTest(String fileName) {
         this.inputJson = String.format(INPUT_CONTEXT_PATH_FORMAT, fileName);
         this.expectedOutput = String.format(EXPECTED_OUTPUT_CONTEXT_PATH, fileName);
@@ -87,7 +84,7 @@ public class PDFGenerationTest extends IntegrationTest {
 
         List testData = new ArrayList(basicTestData);
 
-        if (featureToggleRespSolicitor) {
+        if (getFeatureToggleRespSolicitor()) {
             testData.addAll(Arrays.asList(new Object[][] {
                 {"AOS_Solicitor"},
                 {"AOS_Hus_Res-Addr_DivUnit-SC-Sol-Online-Avl"},

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/PDFGenerationTest.java
@@ -9,7 +9,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 
 import java.io.File;

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -38,4 +38,4 @@ document.management.store.baseUrl=http://localhost:3404
 ###############################################
 #  Feature Toggles                            #
 ###############################################
-feature-toggle.resp-solicitor-details=${FEATURE_RESP_SOLICITOR_DETAILS:false}
+feature-toggle.resp-solicitor-details=${FEATURE_RESP_SOLICITOR_DETAILS:true}

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -34,3 +34,8 @@ divorce.document.generator.uri=${document.generator.base.uri}/version/1/generate
 #  DM Store                                   #
 ###############################################
 document.management.store.baseUrl=http://localhost:3404
+
+###############################################
+#  Feature Toggles                            #
+###############################################
+feature-toggle.resp-solicitor-details=${FEATURE_RESP_SOLICITOR_DETAILS:false}

--- a/src/integrationTest/resources/example-application-local.properties
+++ b/src/integrationTest/resources/example-application-local.properties
@@ -37,3 +37,8 @@ divorce.document.generator.uri=${document.generator.base.uri}/version/1/generate
 document.management.store.baseUrl=http://dm-store-saat.service.core-compute-saat.internal
 
 http.proxy=http://proxyout.reform.hmcts.net:8080
+
+###############################################
+#  Feature Toggles                            #
+###############################################
+feature-toggle.resp-solicitor-details=true


### PR DESCRIPTION
Missing flag meant integration tests was resolving the feature toggle for solicitor as false, when AKS was setting true.