### PR TITLE
Upgrade versions for CVE issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ def versions = [
     feignHttpClient: '10.2.0',
     gradlePitest: '1.3.0',
     guava: '27.0.1-jre',
-    jacksonDatabind: '2.9.9',
+    jacksonDatabind: '2.9.9.1',
     jsonAssert: '1.2.3',
     junit: '4.12',
     lombok: '1.16.16',
@@ -181,13 +181,13 @@ dependencies {
         force = true
     }
 
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-core', version: '9.0.19') {
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-core', version: '9.0.22') {
         force = true
     }
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-websocket', version: '9.0.19') {
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-websocket', version: '9.0.22') {
         force = true
     }
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-el', version: '9.0.19') {
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-el', version: '9.0.22') {
         force = true
     }
 


### PR DESCRIPTION
Upgrades to latest Jackson Data Bind and TomCat versions for the dependency check.