### PR TITLE
DIV-5517 - added missing test_environment setup for AAT

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -45,6 +45,10 @@ withPipeline(type , product, component) {
         echo '${product}-${component} checked out'
     }
 
+    before('functionalTest:aat') {
+        env.test_environment = 'aat'
+    }
+
     // Kubernetes does not retrieve variables from the output terraform
     before('functionalTest:preview') {
         env.FEATURE_RESP_SOLICITOR_DETAILS = 'false'


### PR DESCRIPTION
# Description

Due to the change in #194 (enable staging deployment) we need to explicitly set test_environment for the AAT tests to pick up application-aat.properties 

Fixes #DIV-5517 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
