### PR TITLE
DIV-5762 - use java chart v2.6.0 and reduced duplicated env references

### DIFF
--- a/charts/div-dgs/Chart.yaml
+++ b/charts/div-dgs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Document Generator Service
 name: div-dgs
-version: 1.1.0
+version: 1.3.0

--- a/charts/div-dgs/Chart.yaml
+++ b/charts/div-dgs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Document Generator Service
 name: div-dgs
-version: 1.3.0
+version: 1.2.0

--- a/charts/div-dgs/requirements.yaml
+++ b/charts/div-dgs/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
     - name: java
-      version: ~2.3.1
+      version: ~2.6.0
       repository: "@hmctspublic"

--- a/charts/div-dgs/values.aat.template.yaml
+++ b/charts/div-dgs/values.aat.template.yaml
@@ -1,10 +1,5 @@
 java:
     environment:
-        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        EVIDENCE_MANAGEMENT_CLIENT_API_BASEURL : "http://div-emca-aat.service.core-compute-aat.internal"
-        IDAM_S2S_URL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        PDF_SERVICE_BASEURL : "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
-        DOCMOSIS_SERVICE_BASE_URL: "https://docmosis-development.platform.hmcts.net"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
         FEATURE_RESP_SOLICITOR_DETAILS: "true"
         DOCMOSIS_SERVICE_DEV_MODE_FLAG: "true"

--- a/charts/div-dgs/values.preview.template.yaml
+++ b/charts/div-dgs/values.preview.template.yaml
@@ -1,10 +1,5 @@
 java:
     environment:
-        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        EVIDENCE_MANAGEMENT_CLIENT_API_BASEURL : "http://div-emca-aat.service.core-compute-aat.internal"
-        IDAM_S2S_URL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        PDF_SERVICE_BASEURL : "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
-        DOCMOSIS_SERVICE_BASE_URL: "https://docmosis-development.platform.hmcts.net"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
         FEATURE_RESP_SOLICITOR_DETAILS: "true"
         DOCMOSIS_SERVICE_DEV_MODE_FLAG: "true"

--- a/charts/div-dgs/values.yaml
+++ b/charts/div-dgs/values.yaml
@@ -1,6 +1,11 @@
 java:
     applicationPort: 4007
     environment:
+        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        EVIDENCE_MANAGEMENT_CLIENT_API_BASEURL: "http://div-emca-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        IDAM_S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        PDF_SERVICE_BASEURL: "http://cmc-pdf-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        DOCMOSIS_SERVICE_BASE_URL: "https://docmosis-development.platform.hmcts.net"
         REFORM_SERVICE_NAME: "dgs"
         REFORM_TEAM: "div"
         AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: "divorce_document_generator"
@@ -8,7 +13,7 @@ java:
         EVIDENCE_MANAGEMENT_CLIENT_API_HEALTH_ENDPOINT: "/health"
     keyVaults:
         "div":
-            resourceGroup: div   
+            resourceGroup: div
             secrets:
                 - div-doc-s2s-auth-secret
                 - docmosis-api-key

--- a/charts/div-dgs/values.yaml
+++ b/charts/div-dgs/values.yaml
@@ -1,5 +1,6 @@
 java:
     applicationPort: 4007
+    ingressHost: "div-dgs-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     environment:
         AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         EVIDENCE_MANAGEMENT_CLIENT_API_BASEURL: "http://div-emca-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"


### PR DESCRIPTION
# Description

Reduced duplicated config values by moving them to values.yaml
And using {{ .Values.global.environment }} placeholder
Also removed unused env variables (if any)

See 
* https://github.com/hmcts/chart-java/pull/61 
* https://hmcts-reform.slack.com/archives/CLE7A3SKV/p1568286603003800

Fixes #DIV-5762

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

