### PR TITLE
Removed docmosis config

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,4 +1,3 @@
 vault_env = "preprod"
 capacity = "2"
 
-docmosis_dev_mode_flag = "true"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -15,8 +15,6 @@ locals {
   vaultName = "${var.env == "preview" ? local.previewVaultName : local.nonPreviewVaultName}"
   vaultUri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
 
-  docmosis_key_vault_uri = "https://${var.docmosis_key_vault_name}.vault.azure.net/"
-
   asp_name = "${var.env == "prod" ? "div-dgs-prod" : "${var.raw_product}-${var.env}"}"
   asp_rg = "${var.env == "prod" ? "div-dgs-prod" : "${var.raw_product}-${var.env}"}"
 }
@@ -39,14 +37,4 @@ data "azurerm_key_vault_secret" "div-doc-s2s-auth-secret" {
 data "azurerm_key_vault_secret" "idam-secret" {
     name      = "idam-secret"
     vault_uri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
-}
-
-data "azurerm_key_vault_secret" "docmosis_api_key" {
-  name      = "docmosis-api-key"
-  vault_uri = "${local.docmosis_key_vault_uri}"
-}
-
-data "azurerm_key_vault_secret" "docmosis_endpoint" {
-  name      = "docmosis-endpoint"
-  vault_uri = "${local.docmosis_key_vault_uri}"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -97,12 +97,3 @@ variable "feature_resp_solicitor_details" {
   default = "false"
 }
 
-variable "docmosis_key_vault_name" {
-  type    = "string"
-  default = "docmosisiaasdevkv"
-}
-
-variable "docmosis_dev_mode_flag" {
-  type    = "string"
-  default = "false"
-}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -79,7 +79,9 @@ variable "location" {
 
 variable "ilbIp" {}
 
-variable "vault_env" {}
+variable "vault_env" {
+    default = "preprod"
+}
 
 variable "common_tags" {
     type = "map"


### PR DESCRIPTION
# Description
We don't seem to have access to the docmosis vault in TF, but we don't need it as we switched to AKS so removing config related to this

Fixes pipeline

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
