### PR TITLE
DIV-6317: update vars 'courtOrderBeenGranted' -> 'costClaimGranted'

### DIFF
--- a/src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted and cost order for respondent.json
+++ b/src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted and cost order for respondent.json
@@ -13,7 +13,7 @@
                 "respondentFullName": "Respondent Baker",
                 "letterDate": "05 May 2020",
                 "hearingDate": "15 Jun 2020",
-                "courtOrderBeenGranted": true,
+                "costClaimGranted": true,
                 "ctscContactDetails": {
                     "serviceCentre": "Courts and Tribunals Service Centre",
                     "careOf": "HMCTS Digital Divorce",

--- a/src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted for respondent.json
+++ b/src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted for respondent.json
@@ -13,7 +13,7 @@
                 "respondentFullName": "Respondent Baker",
                 "letterDate": "05 May 2020",
                 "hearingDate": "15 Jun 2020",
-                "courtOrderBeenGranted": false,
+                "costClaimGranted": false,
                 "ctscContactDetails": {
                     "serviceCentre": "Courts and Tribunals Service Centre",
                     "careOf": "HMCTS Digital Divorce",


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/DIV-6317

Docmosis update:
https://github.com/hmcts/rdo-docmosis/pull/271

It will fail for now. I need to merge updated template first and re-generate 2 pdfs:
- src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted and cost order for respondent.json
- src/integrationTest/resources/documentgenerator/documents/jsoninput/DN granted for respondent.json