### PR TITLE
Bump tomcatEmbededCore and tomcatEmbededWebsocket cve-2020-11996

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,8 @@ def versions = [
     wiremockVersion: '2.19.0',
     reformSpringBootAutoConfigure: '2.0.0',
     springSecurityCrypto: '5.2.4.RELEASE',
-    tomcatEmbedCore: '9.0.35',
-    tomcatEmbedWebsocket: '9.0.35',
+    tomcatEmbedCore: '9.0.37',
+    tomcatEmbedWebsocket: '9.0.37',
     tomcatEmbedEl: '9.0.33'
 ]
 


### PR DESCRIPTION
# Description

Bumped versions of tomcatEmbededCore and tomcatEmbededWebsocket to 9.0.37 from 9.0.35 due to [CVE-2020-11996](https://nvd.nist.gov/vuln/detail/CVE-2020-11996#range-5413096)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
