### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ def versions = [
     powerMock: '2.0.0',
     puppyCrawl: '8.29',
     reformPropertiesVolume: '0.0.4',
-    reformsJavaLogging: '5.1.5',
+    reformsJavaLogging: '6.0.1',
     restAssured: '3.0.3',
     serenity: '2.2.13',
     serenityCucumber: '1.9.51',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.