### PR TITLE
Update respondent declaration

### DIFF
--- a/src/main/resources/data/templates/respondentAnswers.html
+++ b/src/main/resources/data/templates/respondentAnswers.html
@@ -336,7 +336,7 @@
 <p class="single-block">
 <h2 class="heading-medium">Statement of truth</h2>
 <p class="response-text">
-    "I believe that the facts stated in this application are true."
+    "I believe that the facts stated in this response are true."
 </p>
 <p class="signature">
     {% autoescape false %}


### PR DESCRIPTION
# Description

The document generator is currently generating what may amount to false declarations in the case that a respondent is responding to a sole application.

Respondents who are not represented by a solicitor are asked by `div-respondent-frontend` to make the following declaration:

> I believe that the facts stated in this response are true.

followed by a warning:

> Proceedings for contempt of court may be brought against anyone who makes, or causes to be made, a false statement verified by a statement of truth without an honest belief in its truth.

https://github.com/hmcts/div-respondent-frontend/blob/401d8984f348ea94390fab52f2a51bd997b71d96/steps/respondent/check-your-answers/CheckYourAnswers.content.json#L7 and https://github.com/hmcts/div-respondent-frontend/blob/401d8984f348ea94390fab52f2a51bd997b71d96/steps/respondent/check-your-answers/CheckYourAnswers.html#L58

![image](https://github.com/hmcts/div-document-generator-client/assets/517837/1981ced5-d8ab-4bc0-a0ef-3ab5aa423ee6)

But when they download their response (generated by `div-document-generator-client `) as a PDF, the document includes the declaration:

> "I believe the facts stated in this application are true."

undersigned by the respondents name.

<img width="473" alt="image" src="https://github.com/hmcts/div-document-generator-client/assets/517837/6f9508b7-4cc8-4b6e-b7e8-8cd4f6968238">

This is incorrect, since at no point is the respondent asked to declare the _application_ facts are true.

Indeed, respondents may well disagree with the application; they are asked only to acknowledge that they have read it: https://github.com/hmcts/div-respondent-frontend/blob/401d8984f348ea94390fab52f2a51bd997b71d96/steps/respondent/review-application/ReviewApplication.content.json#L58 and https://github.com/hmcts/div-respondent-frontend/blob/401d8984f348ea94390fab52f2a51bd997b71d96/steps/respondent/review-application/ReviewApplication.content.json#L146

I have therefore updated the respondent template to reflect the declaration that respondents have actually made.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] May require a review of all documents generated to date/communication to the courts

# How Has This Been Tested?

I have not tested this change as I do not have a suitable development environment. I would welcome assistance from the service team in validating it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
