### PR TITLE
Update PdfGGenerationServiceConsumerTest.java

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>hmcts/.github:renovate-config",
+    "local>hmcts/.github//renovate/automerge-all"
+  ]
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/divorce/documentgenerator/PdfGGenerationServiceConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/divorce/documentgenerator/PdfGGenerationServiceConsumerTest.java
@@ -83,7 +83,6 @@ public class PdfGGenerationServiceConsumerTest {
                 "application/vnd.uk.gov.hmcts.pdf-service.v2+json;charset=UTF-8")
             .path("/pdfs")
             .willRespondWith()
-            .withBinaryData("".getBytes(), "application/octet-stream")
             .matchHeader(org.springframework.http.HttpHeaders.CONTENT_TYPE, "application/pdf")
             .status(HttpStatus.SC_OK)
             .toPact();


### PR DESCRIPTION
- Remove unneeded check as it fails in latest versions of pact.
- Next line already checks the contentype header.